### PR TITLE
Fix Cloudflare RSC caching bug and reduce database load

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,17 @@ const nextConfig: NextConfig = {
 	images: {
 		unoptimized: true,
 	},
+	async headers() {
+		return [
+			{
+				// Prevent Cloudflare from serving cached HTML for RSC navigation requests
+				source: "/:path*",
+				headers: [
+					{ key: "Vary", value: "RSC, Next-Router-State-Tree, Next-Router-Prefetch" },
+				],
+			},
+		];
+	},
 };
 
 export default nextConfig;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,7 @@ model Mii {
   @@index([gender])
   @@index([makeup])
   @@index([quarantined, id])
+  @@index([in_queue, quarantined, createdAt(sort: Desc)])
   @@map("miis")
 }
 

--- a/src/components/mii/list/index.tsx
+++ b/src/components/mii/list/index.tsx
@@ -108,7 +108,6 @@ export default async function MiiList({ searchParams, userId, parentPage }: Prop
 	const skip = (page - 1) * limit;
 
 	let totalCount: number;
-	let filteredCount: number;
 	let miis: Prisma.MiiGetPayload<{ select: typeof select }>[];
 
 	if (sort === "random") {
@@ -119,7 +118,6 @@ export default async function MiiList({ searchParams, userId, parentPage }: Prop
 		});
 
 		totalCount = matchingIds.length;
-		filteredCount = Math.max(0, Math.min(limit, totalCount - skip));
 
 		if (matchingIds.length === 0) return;
 
@@ -155,14 +153,13 @@ export default async function MiiList({ searchParams, userId, parentPage }: Prop
 			orderBy = [{ createdAt: "desc" }, { name: "asc" }];
 		}
 
-		[totalCount, filteredCount, miis] = await Promise.all([
+		[totalCount, miis] = await Promise.all([
 			prisma.mii.count({ where: { ...where, userId } }),
-			prisma.mii.count({ where, skip, take: limit }),
 			prisma.mii.findMany({
 				where,
 				orderBy,
 				select,
-				skip: (page - 1) * limit,
+				skip,
 				take: limit,
 			}),
 		]);
@@ -174,19 +171,8 @@ export default async function MiiList({ searchParams, userId, parentPage }: Prop
 		<div className="w-full">
 			<div className="bg-amber-50 border-2 border-amber-500 rounded-2xl shadow-lg p-4 flex justify-between items-center gap-2 mb-2 max-md:flex-col">
 				<div className="flex items-center gap-2">
-					{totalCount == filteredCount ? (
-						<>
-							<span className="text-2xl font-bold text-amber-900">{totalCount}</span>
-							<span className="text-lg text-amber-700">{totalCount === 1 ? "Mii" : "Miis"}</span>
-						</>
-					) : (
-						<>
-							<span className="text-2xl font-bold text-amber-900">{filteredCount}</span>
-							<span className="text-sm text-amber-700">of</span>
-							<span className="text-lg font-semibold text-amber-800">{totalCount}</span>
-							<span className="text-lg text-amber-700">Miis</span>
-						</>
-					)}
+					<span className="text-2xl font-bold text-amber-900">{totalCount}</span>
+					<span className="text-lg text-amber-700">{totalCount === 1 ? "Mii" : "Miis"}</span>
 				</div>
 
 				<div className="relative flex items-center justify-end gap-2 w-full md:max-w-2/3 max-md:justify-center">

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -68,9 +68,10 @@ export class RateLimit {
 
 			return { success, limit: this.maxRequests, remaining, expires: expireAt };
 		} catch (error) {
+			// Fail open — don't block users when Redis is unreachable
 			console.error("Rate limit check failed", error);
 			return {
-				success: false,
+				success: true,
 				limit: this.maxRequests,
 				remaining: this.maxRequests,
 				expires: expireAt,


### PR DESCRIPTION
  Fixes #27

  **Cloudflare was serving cached HTML for RSC navigation requests**, causing "page couldn't load" errors when changing sort/filters through the UI. Added `Vary: RSC,
  Next-Router-State-Tree, Next-Router-Prefetch` headers so Cloudflare caches them as separate entries.

  Also includes a few small performance/reliability fixes:
  - Removed a wasted `filteredCount` database query that ran on every page load but never returned a meaningful value (count with skip/take just returns page size)
  - Rate limiter now fails open when Redis is unreachable instead of blocking all requests
  - Fixed a crash when `sort=random` matched zero Miis (returned undefined instead of JSON)
  - Added composite index on `(in_queue, quarantined, createdAt)` for the default homepage query

  **Note:** Requires `prisma migrate` for the new index, and a Cloudflare cache purge after deploy.