### PR TITLE
fix: handle not found errors for Mii and User in API responses

### DIFF
--- a/backend/src/app/api/mii/[id]/info/route.ts
+++ b/backend/src/app/api/mii/[id]/info/route.ts
@@ -34,5 +34,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 		},
 	});
 
+	if (!mii) return NextResponse.json({ error: "Mii not found" }, { status: 404 });
+
 	return NextResponse.json(mii);
 }

--- a/backend/src/app/api/profile/[id]/info/route.ts
+++ b/backend/src/app/api/profile/[id]/info/route.ts
@@ -21,5 +21,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 		},
 	});
 
+	if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
+
 	return NextResponse.json(user);
 }

--- a/frontend/src/pages/mii.tsx
+++ b/frontend/src/pages/mii.tsx
@@ -32,6 +32,8 @@ export default function MiiPage() {
 				return res.json();
 			})
 			.then((data) => {
+				if (!data) throw new Error("Mii not found");
+
 				setMii(data);
 				setLoading(false);
 

--- a/frontend/src/pages/profile/layout.tsx
+++ b/frontend/src/pages/profile/layout.tsx
@@ -28,6 +28,8 @@ export default function ProfileLayout() {
 				return res.json();
 			})
 			.then((data) => {
+				if (!data) throw new Error("Profile not found");
+
 				setUser(data);
 				setLoading(false);
 			})
@@ -42,11 +44,11 @@ export default function ProfileLayout() {
 		return <div className="p-6 text-center">Loading...</div>;
 	}
 
-	const currentUser = user ?? $session?.user;
+	const sessionUserId = $session?.user?.id ? Number($session.user.id) : null;
 	const page = location.pathname;
-	const isAdmin = currentUser?.id === Number(import.meta.env.VITE_ADMIN_USER_ID);
-	const isContributor = import.meta.env.VITE_CONTRIBUTORS_USER_IDS?.split(",").includes(user?.id);
-	const isOwnProfile = currentUser?.id === user?.id;
+	const isAdmin = sessionUserId === Number(import.meta.env.VITE_ADMIN_USER_ID);
+	const isContributor = import.meta.env.VITE_CONTRIBUTORS_USER_IDS?.split(",").includes(String(user?.id));
+	const isOwnProfile = sessionUserId === user?.id;
 
 	return (
 		<div>


### PR DESCRIPTION
## Description
This PR fixes an issue where non-existent resources cause the application to remain stuck in an infinite loading state instead of returning a proper not found response.

Previously, when a requested resource did not exist, the related APIs returned `200` with `null`. On the frontend, consumer pages kept evaluating the state with conditions such as `loading || !data`, which caused the UI to display a perpetual loading spinner instead of rendering a `404` state.

This change ensures that missing resources are handled correctly, allowing the application to return a proper `404` response and display a not found page or redirect accordingly.

### What was done
- Updated resource handling for non-existent entities in the related info APIs.
- Fixed frontend loading logic to avoid infinite loading when the response data is `null`.
- Ensured missing resources are treated as not found instead of valid empty responses.
- Improved error handling in consumer pages and layouts related to `mii` and `profile`.

### Affected areas
- `mii info` (line 37)
- `profile info` (line 24)
- `mii page` (line 53)
- `profile layout` (line 41)

### Functional impact
This fix resolves a problem where:
- Users could get stuck on an infinite loading screen when opening a non-existent resource.
- Real `404` behavior was not triggered.
- Navigation was blocked on pages with no valid exit path.

## Test cases
#### Requirements
- The application must be running locally or in a test environment.
- Routes for `mii` and `profile` must be accessible.
- Use a non-existent resource ID for validation.

### CASE 1:
Verify that a non-existent `mii` resource returns a proper not found state.

**Steps to test:**
1. Open `/mii/999999999`.
2. Wait for the request to complete.

**Expected result:**
- The request is handled as a missing resource.
- The page does not remain in a loading state.
- A `404` page, not found state, or redirect is shown.

### CASE 2:
Verify that a non-existent `profile` resource returns a proper not found state.

**Steps to test:**
1. Open `/profile/999999999`.
2. Wait for the request to complete.

**Expected result:**
- The request is handled as a missing resource.
- The page does not remain in a loading state.
- A `404` page, not found state, or redirect is shown.

### CASE 3:
Verify that existing resources still load correctly.

**Steps to test:**
1. Open a valid `/mii/{id}` route.
2. Open a valid `/profile/{id}` route.
3. Confirm normal page behavior.

**Expected result:**
- Existing resources load normally.
- No regression is introduced in valid resource flows.

### CASE 4:
Verify that loading state is only shown while the request is actually in progress.

**Steps to test:**
1. Open a valid resource page.
2. Open a non-existent resource page.
3. Compare the loading behavior in both cases.

**Expected result:**
- Loading spinner is shown only during the active fetch.
- Once the request completes, the UI resolves to either valid content or a proper not found state.