### PR TITLE
fix: update tag links to use query parameters

### DIFF
--- a/frontend/src/pages/mii.tsx
+++ b/frontend/src/pages/mii.tsx
@@ -270,7 +270,7 @@ export default function MiiPage() {
 							{/* Tags */}
 							<div id="tags" className="flex flex-wrap gap-1 mt-1 *:px-2 *:py-1 *:bg-orange-300 *:rounded-full *:text-xs">
 								{mii.tags.map((tag: string) => (
-									<Link to={`/tags=${tag}`} key={tag}>
+									<Link to={`/?tags=${encodeURIComponent(tag)}`} key={tag}>
 										{tag}
 									</Link>
 								))}


### PR DESCRIPTION
## Description
This PR fixes broken navigation when clicking tags from the Mii detail page.

Previously, tag links were generated using the route format `/tags={tag}` instead of the expected query parameter format `/?tags={tag}`. Because of this, clicking a tag from the detail page redirected users to a non-existent route instead of taking them to the filtered listing page.

This change updates tag navigation so users are correctly redirected to the list view filtered by the selected tag.

### What was done
- Fixed tag link generation in the Mii detail page.
- Replaced the invalid route format `/tags={tag}` with the correct query parameter format `/?tags={tag}`.
- Restored the expected filtering flow when navigating from a Mii detail page through a tag.

### Functional impact
This fix resolves an issue where:
- Clicking a tag from a Mii detail page led to a broken route.
- Users could not navigate to the filtered content list by tag.
- Contextual navigation and content discovery were interrupted.

## Test cases
#### Requirements
- The application must be running locally or in a test environment.
- At least one Mii detail page must contain visible tags.
- The main listing page must support filtering by the `tags` query parameter.

### CASE 1:
Verify that clicking a tag from the Mii detail page redirects to the filtered listing page.

**Steps to test:**
1. Open any Mii detail page.
2. Click on one of the displayed tags.

**Expected result:**
- The application navigates to the listing page filtered by the selected tag.
- The URL uses the correct query parameter format, for example: `/?tags=example-tag`.