### PR TITLE
fix: remove state management for filters on platform change

### DIFF
--- a/frontend/src/components/mii/list/gender-select.tsx
+++ b/frontend/src/components/mii/list/gender-select.tsx
@@ -1,4 +1,4 @@
-import { useState, useTransition } from "react";
+import { useTransition } from "react";
 import { Icon } from "@iconify/react";
 import type { MiiGender, MiiPlatform } from "@tomodachi-share/shared";
 import { useNavigate, useSearchParams } from "react-router";
@@ -8,12 +8,11 @@ export default function GenderSelect() {
 	const [searchParams] = useSearchParams();
 	const [, startTransition] = useTransition();
 
-	const [selected, setSelected] = useState<MiiGender | null>((searchParams.get("gender") as MiiGender) ?? null);
+	const selected = (searchParams.get("gender") as MiiGender) ?? null;
 	const platform = (searchParams.get("platform") as MiiPlatform) || undefined;
 
 	const handleClick = (gender: MiiGender) => {
 		const filter = selected === gender ? null : gender;
-		setSelected(filter);
 
 		const params = new URLSearchParams(searchParams);
 		params.set("page", "1");

--- a/frontend/src/components/mii/list/makeup-select.tsx
+++ b/frontend/src/components/mii/list/makeup-select.tsx
@@ -1,4 +1,4 @@
-import { useState, useTransition } from "react";
+import { useTransition } from "react";
 import { Icon } from "@iconify/react";
 import type { MiiMakeup } from "@tomodachi-share/shared";
 import { useNavigate, useSearchParams } from "react-router";
@@ -8,11 +8,10 @@ export default function MakeupSelect() {
 	const [searchParams] = useSearchParams();
 	const [, startTransition] = useTransition();
 
-	const [selected, setSelected] = useState<MiiMakeup | null>((searchParams.get("makeup") as MiiMakeup) ?? null);
+	const selected = (searchParams.get("makeup") as MiiMakeup) ?? null;
 
 	const handleClick = (makeup: MiiMakeup) => {
 		const filter = selected === makeup ? null : makeup;
-		setSelected(filter);
 
 		const params = new URLSearchParams(searchParams);
 		params.set("page", "1");

--- a/frontend/src/components/mii/list/other-filters.tsx
+++ b/frontend/src/components/mii/list/other-filters.tsx
@@ -1,5 +1,5 @@
 import type { MiiPlatform } from "@tomodachi-share/shared";
-import { type ChangeEvent, useState, useTransition } from "react";
+import { type ChangeEvent, useTransition } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 export default function OtherFilters() {
@@ -9,16 +9,14 @@ export default function OtherFilters() {
 	const [, startTransition] = useTransition();
 
 	const platform = (searchParams.get("platform") as MiiPlatform) || undefined;
-	const [allowCopying, setAllowCopying] = useState<boolean>((searchParams.get("allowCopying") as unknown as boolean) ?? false);
-	const [quarantined, setQuarantined] = useState<boolean>((searchParams.get("quarantined") as unknown as boolean) ?? false);
+	const allowCopying = searchParams.get("allowCopying") === "true";
+	const quarantined = searchParams.get("quarantined") === "true";
 
 	const handleChangeAllowCopying = (e: ChangeEvent<HTMLInputElement>) => {
-		setAllowCopying(e.target.checked);
-
 		const params = new URLSearchParams(searchParams);
 		params.set("page", "1");
 
-		if (!allowCopying) {
+		if (e.target.checked) {
 			params.set("allowCopying", "true");
 		} else {
 			params.delete("allowCopying");
@@ -30,12 +28,10 @@ export default function OtherFilters() {
 	};
 
 	const handleChangeQuarantined = (e: ChangeEvent<HTMLInputElement>) => {
-		setQuarantined(e.target.checked);
-
 		const params = new URLSearchParams(searchParams);
 		params.set("page", "1");
 
-		if (!quarantined) {
+		if (e.target.checked) {
 			params.set("quarantined", "true");
 		} else {
 			params.delete("quarantined");

--- a/frontend/src/components/mii/list/platform-select.tsx
+++ b/frontend/src/components/mii/list/platform-select.tsx
@@ -1,4 +1,4 @@
-import { useState, useTransition } from "react";
+import { useTransition } from "react";
 import { Icon } from "@iconify/react";
 import type { MiiPlatform } from "@tomodachi-share/shared";
 import { useNavigate, useSearchParams } from "react-router";
@@ -7,19 +7,22 @@ export default function PlatformSelect() {
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
 	const [, startTransition] = useTransition();
-
-	const [selected, setSelected] = useState<MiiPlatform | null>((searchParams.get("platform") as MiiPlatform) ?? null);
+	const selected = (searchParams.get("platform") as MiiPlatform) ?? null;
 
 	const handleClick = (platform: MiiPlatform) => {
 		const filter = selected === platform ? null : platform;
-		setSelected(filter);
 
 		const params = new URLSearchParams(searchParams);
+		params.set("page", "1");
+
 		if (filter) {
 			params.set("platform", filter);
 		} else {
 			params.delete("platform");
 		}
+		if (params.get("gender") === "NONBINARY") params.delete("gender");
+		params.delete("makeup");
+		params.delete("allowCopying");
 
 		startTransition(() => {
 			navigate(`?${params.toString()}`);


### PR DESCRIPTION
## Description
This PR simplifies filter state management by removing unnecessary local `useState` usage and deriving selected filter values directly from the URL search parameters.

This change makes the filter components more predictable, reduces duplicated state, and prevents desynchronization issues between the UI and the URL.

Additionally, the filter logic was updated so that some filters are reset when the selected platform changes. This is necessary because certain filters are not available for all platform types, and keeping them applied across incompatible platforms could lead to invalid or inconsistent filter combinations.

### What was done
- Removed unnecessary local state from:
  - `gender-select.tsx`
  - `makeup-select.tsx`
  - `platform-select.tsx`
  - `other-filters.tsx`
- Derived selected filter values directly from `searchParams`.
- Simplified filter handling logic for better clarity and consistency.
- Updated `OtherFilters` change handlers to use the event's `checked` value directly.
- Updated `PlatformSelect` logic to reset related filters when the platform changes.
- Added reset behavior for filters that are not valid across all platform types:
  - `gender`
  - `makeup`
  - `allowCopying`

### Why this change was needed
Some filters do not exist for other platform types. Because of that, when switching platforms, previously selected filters could remain active in the URL even though they were no longer visible or applicable in the UI.

This caused invalid filter combinations and inconsistent behavior in the search flow.

With this change, incompatible filters are cleared when the platform changes, keeping the filter state valid and aligned with the available options for the selected platform.

### Functional impact
This refactor improves:
- consistency between the UI and the URL
- predictability of filter behavior
- maintainability of filter components
- correctness when switching between platform types

It also prevents bugs caused by stale filter values remaining active after changing platform.

## Test cases
#### Requirements
- The application must be running locally or in a test environment.
- The search page must support filtering by platform and related filters.
- The selected filters must be reflected in the URL search parameters.

### CASE 1:
Verify that filter values are correctly derived from the URL.

**Steps to test:**
1. Open the search page with filter query parameters in the URL.
2. Review the selected values in:
   - platform
   - gender
   - makeup
   - other filters

**Expected result:**
- The UI reflects the values from the URL correctly.
- No local state mismatch occurs.