### PR TITLE
fix: add prisma generate to scripts in package.json

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,8 @@
 		"build": "next build",
 		"start": "next start",
 		"lint": "next lint",
-		"postinstall": "prisma generate"
+		"postinstall": "prisma generate",
+		"prisma": "prisma generate"
 	},
 	"dependencies": {
 		"@2toad/profanity": "^3.3.0",


### PR DESCRIPTION
**Issue**
Initial repository setup is being blocked by the `pnpm --filter backend prisma migrate dev` command, which throws an ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT error.

**Fix**
Add `"prisma": "prisma generate"` to backend/package.json.